### PR TITLE
Added imagemagick to default installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install zip unzip
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tree
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install imagemagick
 # For PPAs
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
 

--- a/system_report.sh
+++ b/system_report.sh
@@ -45,6 +45,7 @@ ver_line="$(zip -v | head -n 2 | tail -n 1)";     echo "* zip: $ver_line"
 ver_line="$(tar --version | head -n 1)" ;         echo "* tar: $ver_line"
 ver_line="$(tree --version)" ;                    echo "* tree: $ver_line"
 ver_line="$(gcc --version | head -n 1)" ;         echo "* gcc: $ver_line"
+ver_line="$(convert --version | head -1)" ;       echo "* imagemagick (convert): $ver_line"
 
 echo
 ver_line="$(sudo --version 2>&1 | grep 'Sudo version')" ; echo "* sudo: $ver_line"


### PR DESCRIPTION
As noted on https://discuss.bitrise.io/t/add-imagemagic-to-the-linux-stack/674, this binary exists on osX based images but lacked on linux based images.
Without this binary, the mini_magick ruby gem (which is installed) will fail to do anything.