### PR TITLE
Add Docker for Mac support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq
 RUN DEBIAN_FRONTEND=noninteractive apt-get purge lxc-docker*
 RUN DEBIAN_FRONTEND=noninteractive apt-cache policy docker-engine
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y linux-image-extra-`uname -r`
+# Includes linux-image-extra-*-generic
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends linux-generic-lts-xenial
 
 # For available docker-engine versions
 #  you can run `sudo apt-get update && sudo apt-cache policy docker-engine`


### PR DESCRIPTION
Installing `linux-generic-lts-xenial` also installs `linux-image-extra-*`.

Is there any downside to installing the linux image via the `linux-generic-lts-xenial` package? 

Here's example RUN step which demonstrates parsing the linux version from the installed linux package. It verifies the linux-image-extra package is already installed.

```Dockerfile
# Includes linux-image-extra-*-generic
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends linux-generic-lts-xenial
# use Ruby instead of uname -r for Docker for Mac support.
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y linux-image-extra-`ruby -e 'puts %x(dpkg -l linux-image-*-generic).match(/linux-image-([^\s]+)/)[1]'`	
```