### PR TITLE
`clang` added to preinstalled packages list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UPCOMING
 
+# `v2017_08_14_1`
+
+* `clang` is now pre-installed
+
 ## `v2017_08_08_1`
 
 * `bitrise` (CLI): `1.8.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
     zip \
     unzip \
     tree \
+    clang \
     imagemagick \
 # For PPAs
     software-properties-common
@@ -193,5 +194,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git-lfs \
 
 WORKDIR $BITRISE_SOURCE_DIR
 
-ENV BITRISE_DOCKER_REV_NUMBER_BASE v2017_08_08_1
+ENV BITRISE_DOCKER_REV_NUMBER_BASE v2017_08_14_1
 CMD bitrise --version

--- a/system_report.sh
+++ b/system_report.sh
@@ -68,6 +68,7 @@ ver_line="$(zip -v | head -n 2 | tail -n 1)";     echo "* zip: $ver_line"
 ver_line="$(tar --version | head -n 1)" ;         echo "* tar: $ver_line"
 ver_line="$(tree --version)" ;                    echo "* tree: $ver_line"
 ver_line="$(gcc --version | head -n 1)" ;         echo "* gcc: $ver_line"
+ver_line="$(clang --version | head -n 1)" ;       echo "* clang: $ver_line"
 ver_line="$(convert --version | head -1)" ;       echo "* imagemagick (convert): $ver_line"
 
 echo


### PR DESCRIPTION
Clang seems to be preinstalled on macOS stacks but is missing on Linux ones.
That toolchain is officially supported by Gradle on Linux: https://docs.gradle.org/current/userguide/native_software.html#native-binaries:tool-chain-support so it should be available to take full advantage of Gradle.