### PR TITLE
change the format of docker images in system report

### DIFF
--- a/system_report.sh
+++ b/system_report.sh
@@ -118,7 +118,7 @@ echo
 
 echo
 echo "=== Docker pre-cached images ==========="
-docker images
+docker images --format '{{ .Repository }} - {{ .Size }}'
 echo "========================================"
 echo
 


### PR DESCRIPTION
tag is irrelevant as when we generate the system reports we use alpha images, but the final production ones are tagged versions of the alphas